### PR TITLE
Tiny regression bug

### DIFF
--- a/mongo_datatables/datatables.py
+++ b/mongo_datatables/datatables.py
@@ -25,7 +25,7 @@ class DataTables(object):
 
     @property
     def db(self):
-        return self.mongo.db
+        return self.mongo
 
     @property
     def search_terms(self):


### PR DESCRIPTION
Hi, it's me again! :)

In the new version the "db" property was changed from this:

    @property
    def db(self):
        return self.mongo

to this:

    @property
    def db(self):
        return self.mongo.db

I don't think that this was intended since this pre-determines the collection to be "db" and also conflicts with the actual query call:

        _results = list(self.db[self.collection].aggregate(_agg))

